### PR TITLE
simplemde source -> fontawesome 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install vue-simplemde --save
 </script>
 
 <style>
-  @import '~simplemde/dist/simplemde.min.css';
+  @import '~easymde/dist/easymde.min.css';
 </style>
 ```
 
@@ -43,7 +43,7 @@ npm install vue-simplemde --save
 ``` javascript
 import Vue from 'vue'
 import VueSimplemde from 'vue-simplemde'
-import 'simplemde/dist/simplemde.min.css'
+import 'easymde/dist/easymde.min.css';
 
 Vue.use(VueSimplemde)
 ```
@@ -76,7 +76,7 @@ $ npm install --save github-markdown-css
 </template>
 
 <style>
-  @import '~simplemde/dist/simplemde.min.css';
+  @import '~easymde/dist/easymde.min.css';
   @import '~github-markdown-css';
 </style>
 ```
@@ -101,13 +101,13 @@ $ npm install --save highlight.js
 </script>
 
 <style>
-  @import '~simplemde/dist/simplemde.min.css';
+  @import '~easymde/dist/easymde.min.css';
   @import '~highlight.js/styles/atom-one-dark.css';
   /* Highlight theme list: https://github.com/isagalaev/highlight.js/tree/master/src/styles */
 </style>
 ```
 
-## Editor Theme ([simplemde-theme-base](https://github.com/xcatliu/simplemde-theme-base/wiki/List-of-themes))
+## Editor Theme ([simplemde-theme-base](https://github.com/xcatliu/simplemde-theme-base/wiki/List-of-themes)) [deprecated?]
 > e.g. use simplemde-theme-base theme
 
 ### install

--- a/examples/index.vue
+++ b/examples/index.vue
@@ -83,5 +83,5 @@
 </script>
 
 <style>
-  @import '~simplemde/dist/simplemde.min.css';
+  @import '~easymde/dist/easymde.min.css';
 </style>

--- a/examples/nuxt/nuxt.config.js
+++ b/examples/nuxt/nuxt.config.js
@@ -4,6 +4,6 @@ module.exports = {
     { src: '~plugins/nuxt-simplemde-plugin.js', ssr: false }
   ],
   css: [
-    'simplemde/dist/simplemde.min.css'
+    'easymde/dist/easymde.min.css'
   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "marked": "*",
-    "simplemde": "*"
+    "easymde": "https://github.com/Ionaru/easy-markdown-editor",
+    "marked": "*"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/src/markdown-editor.vue
+++ b/src/markdown-editor.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import SimpleMDE from 'simplemde';
+import EasyMDE from 'easymde';
 import marked from 'marked';
 
 export default {
@@ -43,7 +43,7 @@ export default {
     if (this.autoinit) this.initialize();
   },
   activated() {
-    const editor = this.simplemde;
+    const editor = this.easymde;
     if (!editor) return;
     const isActive = editor.isSideBySideActive() || editor.isPreviewActive();
     if (isActive) editor.toggleFullScreen();
@@ -70,7 +70,7 @@ export default {
       marked.setOptions({ sanitize: this.sanitize });
 
       // 实例化编辑器
-      this.simplemde = new SimpleMDE(configs);
+      this.easymde = new EasyMDE(configs);
 
       // 添加自定义 previewClass
       const className = this.previewClass || '';
@@ -80,12 +80,12 @@ export default {
       this.bindingEvents();
     },
     bindingEvents() {
-      this.simplemde.codemirror.on('change', () => {
-        this.$emit('input', this.simplemde.value());
+      this.easymde.codemirror.on('change', () => {
+        this.$emit('input', this.easymde.value());
       });
     },
     addPreviewClass(className) {
-      const wrapper = this.simplemde.codemirror.getWrapperElement();
+      const wrapper = this.easymde.codemirror.getWrapperElement();
       const preview = document.createElement('div');
       wrapper.nextSibling.className += ` ${className}`;
       preview.className = `editor-preview ${className}`;
@@ -93,12 +93,12 @@ export default {
     },
   },
   destroyed() {
-    this.simplemde = null;
+    this.easymde = null;
   },
   watch: {
     value(val) {
-      if (val === this.simplemde.value()) return;
-      this.simplemde.value(val);
+      if (val === this.easymde.value()) return;
+      this.easymde.value(val);
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,17 +1224,17 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror-spell-checker@*:
+codemirror-spell-checker@1.1.2:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
+  resolved "https://registry.yarnpkg.com/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
   integrity sha1-HGYPkIlIPMtRE7m6nKGcP0mTNx4=
   dependencies:
     typo-js "*"
 
-codemirror@*:
-  version "5.47.0"
-  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz#c13a521ae5660d3acc655af252f4955065293789"
-  integrity sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA==
+codemirror@^5.47.0:
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.0.tgz#66e6dae6ca79b955e34b322881ebb7b5512f3cc5"
+  integrity sha512-3Ter+tYtRlTNtxtYdYNPxGxBL/b3cMcvPdPm70gvmcOO2Rauv/fUEewWa0tT596Hosv6ea2mtpx28OXBy1mQCg==
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.0"
@@ -1706,6 +1706,14 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+"easymde@https://github.com/Ionaru/easy-markdown-editor":
+  version "2.6.1"
+  resolved "https://github.com/Ionaru/easy-markdown-editor#786c5b63c6513fbeeb1c9c9247a7b4e39cdb45fa"
+  dependencies:
+    codemirror "^5.47.0"
+    codemirror-spell-checker "1.1.2"
+    marked "^0.6.2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -3018,7 +3026,7 @@ make-dir@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-marked@*:
+marked@*, marked@^0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
   integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
@@ -4246,15 +4254,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "http://registry.npm.taobao.org/signal-exit/download/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simplemde@*:
-  version "1.11.2"
-  resolved "https://registry.npmjs.org/simplemde/-/simplemde-1.11.2.tgz#a23a35d978d2c40ef07dec008c92f070d8e080e3"
-  integrity sha1-ojo12XjSxA7wfewAjJLwcNjggOM=
-  dependencies:
-    codemirror "*"
-    codemirror-spell-checker "*"
-    marked "*"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -4584,7 +4583,7 @@ typedarray@^0.0.6:
 
 typo-js@*:
   version "1.0.3"
-  resolved "https://registry.npmjs.org/typo-js/-/typo-js-1.0.3.tgz#54d8ebc7949f1a7810908b6002c6841526c99d5a"
+  resolved "https://registry.yarnpkg.com/typo-js/-/typo-js-1.0.3.tgz#54d8ebc7949f1a7810908b6002c6841526c99d5a"
   integrity sha1-VNjrx5SfGngQkItgAsaEFSbJnVo=
 
 uglify-js@^2.8.29:


### PR DESCRIPTION
The currently used source for `simplemde` seems not to be maintained anymore. This fork [https://github.com/Ionaru/easy-markdown-editor](https://github.com/Ionaru/easy-markdown-editor) on the other side stills gets regular updates. Therefore I recommend to switch to this simplemde source. This is especially necessary if you intend to use fontawesome version 5 because it breaks the editor, which only supports previous versions as it can be seen here https://github.com/sparksuite/simplemde-markdown-editor/issues/664#issue-278052156