### PR TITLE
Update Nuxt example because some options deprecated

### DIFF
--- a/examples/nuxt/index.vue
+++ b/examples/nuxt/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="wrap">
-    <no-ssr>
+    <client-only>
       <vue-simplemde v-model="content" />
-    </no-ssr>
+    </client-only>
   </div>
 </template>
 

--- a/examples/nuxt/nuxt.config.js
+++ b/examples/nuxt/nuxt.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   // some nuxt config...
   plugins: [
-    { src: '~plugins/nuxt-simplemde-plugin.js', ssr: false },
+    { src: '~plugins/nuxt-simplemde-plugin.js', mode: 'client' },
   ],
   css: [
     'simplemde/dist/simplemde.min.css',


### PR DESCRIPTION
Thanks for this very simple and useful library.
I noticed some nuxt examples contain old options.

■Objective
Update Nuxt example.
Since Nuxt v2.9, some options are changed or will by deprecated.

This PR contains changes of 'client-only' and 'ssr: false'.

■Reference
https://nuxtjs.org/api/components-client-only/
https://nuxtjs.org/api/configuration-plugins/