### PR TITLE
Focus the last editor line on open

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -46,6 +46,12 @@ export default {
     previewRender: {
       type: Function,
     },
+    focusLastLine: {
+      type: Boolean,
+      default() {
+        return false;
+      },
+    },
   },
   data() {
     return {
@@ -93,6 +99,12 @@ export default {
 
       // 绑定事件
       this.bindingEvents();
+
+      // Auto-Focus the last line of the CodeMirror Instance
+      if (this.focusLastLine) {
+        this.simplemde.codemirror.focus();
+        this.simplemde.codemirror.setCursor(this.simplemde.codemirror.lineCount(), 0);
+      }
     },
     bindingEvents() {
       this.simplemde.codemirror.on('change', () => {


### PR DESCRIPTION
This PR adds a new setting (prop), allowing to auto-focus the **last line** of the CodeMirror editor content on open.

As it's not directly simplemde related I added it to the props and not the configs, hope this is okay for you.

#### Usage / Testing instructions:

```javascript
<vue-simplemde 
  :focus-last-line="true" />
```

or 

```javascript
<vue-simplemde 
  focus-last-line />
```

Thank you!