### PR TITLE
Fix problems with `marked@4.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "marked": "*",
+    "marked": "^3.0.8",
     "simplemde": "*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,6 +5191,11 @@ marked@*:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
   integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
+marked@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
+  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
The 4.0.0 release of the `marked` package contains a breaking change that - guess what - breaks the `<VueSimpleMDE>` component. The main change is that the `marked` package does NOT provide a default export anymore.

For more information please see the [release notes for `marked@4.0.0`](https://github.com/markedjs/marked/releases/tag/v4.0.0). Also, you might be interested in a [related pull request inside the SimpleMDE repo](https://github.com/sparksuite/simplemde-markdown-editor/pull/825).